### PR TITLE
Fix crash when the widget is quickly unmounted.

### DIFF
--- a/lib/src/annotation_widget.dart
+++ b/lib/src/annotation_widget.dart
@@ -46,6 +46,9 @@ class _ImageAnnotationState extends State<ImageAnnotation> {
     );
 
     final loadedImage = await completer.future;
+
+    if (!mounted) return;
+
     setState(() {
       imageSize = calculateImageSize(loadedImage);
     });


### PR DESCRIPTION
The `setState` call in the async `loadImageSize` method can cause the Flutter app to crash when the widget is quickly unmounted before the Future can complete.

We can avoid this by adding a check before the setState to see if the widget state is still valid/mounted.